### PR TITLE
rubyのバージョンを更新

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 export IMAGE_FILE=arm64v8/ruby
 export CHROME_IMAGE=seleniarm/standalone-chromium
 export PGSQL_HOST=baukis2-pgsql.lvh.me
-export DYLD_LIBRARY_PATH=$(brew --prefix postgresql@14)/lib/postgresql@14
+export DYLD_LIBRARY_PATH=$(brew --prefix postgresql@17)/lib/postgresql@17
 export REDIS_URL='redis://redis.lvh.me:26379'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.1205)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
     msgpack (1.7.5)
     nap (1.1.0)
@@ -255,6 +256,9 @@ GEM
       net-protocol
     nio4r (2.7.4)
     nkf (0.2.0)
+    nokogiri (1.18.9)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.9-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
@@ -305,6 +309,7 @@ GEM
       racc
     pastel (0.8.0)
       tty-color (~> 0.5)
+    pg (1.6.2)
     pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-linux)
     playwright-ruby-client (1.40.0)
@@ -504,6 +509,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Baukis2 は企業向けの顧客管理システム(Ruby on Rails 学習用サン
 ## 推奨されるシステム環境
 
 * Ubuntu 22.04
-* Ruby 3.4.4
+* Ruby 3.4.5
 * PostgreSQL 17
 
 # 必要なシステム

--- a/devenv/web/Dockerfile
+++ b/devenv/web/Dockerfile
@@ -1,6 +1,6 @@
 # ビルド用コンテナ
-ARG IMAGE_FILE
-FROM $IMAGE_FILE:3.3.6-alpine3.20 AS builder
+ARG IMAGE_FILE=ruby
+FROM ${IMAGE_FILE}:3.4.5-alpine3.21 AS builder
 RUN apk --no-cache add --virtual build-dependencies \
     build-base \
     git \
@@ -33,7 +33,7 @@ RUN rm -rf /usr/local/bundle/cache/*
 # mainコンテナ
 #    ${BROWSER} \
 
-FROM ${IMAGE_FILE}:3.3.6-alpine3.20
+FROM ${IMAGE_FILE}:3.4.5-alpine3.21
 RUN apk --no-cache add \
     build-base \
     bash \

--- a/devenv/web/Dockerfile
+++ b/devenv/web/Dockerfile
@@ -1,37 +1,4 @@
-# ビルド用コンテナ
 ARG IMAGE_FILE=ruby
-FROM ${IMAGE_FILE}:3.4.5-alpine3.21 AS builder
-RUN apk --no-cache add --virtual build-dependencies \
-    build-base \
-    git \
-    make \
-    gcc \
-    g++ \
-    gcompat \
-    zlib-dev \
-    libffi-dev \
-    readline-dev \
-    libxml2-dev \
-    libxslt-dev \
-    postgresql-dev
-RUN apk --no-cache add \
-    bash \
-    postgresql-client \
-    imagemagick \
-    tzdata
-ENV APP_PATH /work/app
-WORKDIR $APP_PATH
-
-COPY Gemfile $APP_PATH
-#COPY Gemfile.lock $APP_PATH
-RUN gem update bundler \
-    && bundle config set force_ruby_platform true \
-    && bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3 \
-    && apk del build-dependencies # --virtual でグルーピングしたpackageを削除
-RUN rm -rf /usr/local/bundle/cache/*
-
-# mainコンテナ
-#    ${BROWSER} \
 
 FROM ${IMAGE_FILE}:3.4.5-alpine3.21
 RUN apk --no-cache add \
@@ -42,6 +9,9 @@ RUN apk --no-cache add \
     curl \
     gcompat \
     gcc \
+    g++ \
+    git \
+    zlib-dev \
     libffi-dev \
     readline-dev \
     libxml2-dev \
@@ -52,12 +22,22 @@ RUN apk --no-cache add \
     nodejs \
     npm \
     imagemagick  \
-    tzdata
+    tzdata \
+    yaml \
+    yaml-dev
 RUN cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
 ENV APP_PATH /work/app
 WORKDIR $APP_PATH
+
+# Gemfileを先にコピーしてbundle installを実行
+COPY Gemfile $APP_PATH
+COPY Gemfile.lock $APP_PATH
+RUN gem update bundler \
+    && bundle config set force_ruby_platform true \
+    && bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3
+
+# その後でアプリケーションコードをコピー
 COPY . $APP_PATH
-COPY --from=builder /usr/local/bundle /usr/local/bundle
 
 CMD ["bin/rails", "s"]


### PR DESCRIPTION
さらに、以下のWARNINGメッセージを抑制する為に書式を変更
```
% docker compose up web
[+] Building 8.2s (15/18)
 => [internal] load local bake definitions                                                                                                                                                   0.0s
 => => reading from stdin 461B                                                                                                                                                               0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                         0.0s
 => => transferring dockerfile: 1.40kB                                                                                                                                                       0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG $IMAGE_FILE:3.4.5-alpine3.21 results in empty or invalid base image name (line 3)                                                   0.0s
```
