### PR TITLE
codecovがきちんとカバレッジレポートを出力していない原因を探る為にログ出力を強化

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -96,4 +96,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
+          fail_ci_if_error: true
+          disable_file_fixes: true
           verbose: true

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -85,9 +85,12 @@ jobs:
           RAILS_ENV: test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-      - name: Show lcov file content
+      - name: Fix lcov file paths and show content
         if: always()
-        run: cat coverage/lcov.info
+        run: |
+          sed -i 's|SF:./|SF:|g' coverage/lcov.info
+          echo "--- Fixed lcov.info content ---"
+          cat coverage/lcov.info
       - name: Codecov
         uses: codecov/codecov-action@v5.5.0
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -90,3 +90,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: coverage # このディレクトリに、テスティングツールによるカバレッジレポートファイルが出力される想定
+          verbose: true

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -95,5 +95,5 @@ jobs:
         uses: codecov/codecov-action@v5.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: coverage # このディレクトリに、テスティングツールによるカバレッジレポートファイルが出力される想定
+          files: coverage/lcov.info
           verbose: true

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -85,6 +85,9 @@ jobs:
           RAILS_ENV: test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
+      - name: Show lcov file content
+        if: always()
+        run: cat coverage/lcov.info
       - name: Codecov
         uses: codecov/codecov-action@v5.5.0
         with:


### PR DESCRIPTION
カバレッジがでてこないのでログ出力してみる。