### PR TITLE
fix(ci): fix release-drafter v7 validation error

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ jobs:
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           publish: true
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,6 +25,8 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v7
         with:
+          # target_commitish が PR 時に解決できないエラー（Validation Failed）を解消するため明示的に指定
+          commitish: master
           # master への push (マージ) 時のみリリースを公開し、PR時は下書き更新のみにする
           publish: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,7 +25,8 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v7
         with:
-          publish: true
+          # master への push (マージ) 時のみリリースを公開し、PR時は下書き更新のみにする
+          publish: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml


### PR DESCRIPTION
release-drafter v7 へのアップデートに伴い発生していた PR 時のバリデーションエラーを解消します。publish オプションを master への push 時のみ有効にすることで、PR 時のタグ名解決失敗を防ぎます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions Release Drafterワークフローをv6からv7にアップグレードしました。
  * リリースプロセスの信頼性向上のため、ワークフロー設定を改善しました。
  * masterブランチへのプッシュ時のリリース公開動作を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->