### PR TITLE
fix: capybara-playwright-driver を 0.5.9 に復元

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-playwright-driver (0.5.8)
+    capybara-playwright-driver (0.5.9)
       addressable
       capybara
       playwright-ruby-client (>= 1.16.0)


### PR DESCRIPTION
## Summary
- #1418 のコンフリクト解消時に意図せず capybara-playwright-driver が 0.5.9 から 0.5.8 にダウングレードされたものを復元します

## Test plan
- [ ] CI が通ることを確認