### PR TITLE
fix: use separate autolabeler action for release-drafter v7

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,19 +8,19 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  # autolabelerのみ（PRイベント時）
-  autolabel:
+  autolabeler:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
-        with:
-          commitish: master
+      - uses: release-drafter/release-drafter/autolabeler@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # リリースドラフト更新＋公開（masterへのpush時のみ）
   update_release_draft:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
@@ -28,6 +28,5 @@ jobs:
       - uses: release-drafter/release-drafter@v7
         with:
           publish: true
-          commitish: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- release-drafter v7ではdrafterとautolabelerが別アクションに分離された
- PR時: `release-drafter/release-drafter/autolabeler@v7` でラベル付与のみ
- push時: `release-drafter/release-drafter@v7` でリリース作成のみ
- `permissions` を明示的に設定

## Test plan
- [ ] PRイベントでautolabelerジョブが成功すること
- [ ] mainへのpush時にリリースが正しく作成されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Chores**
  * 自動ラベリングプロセスを改善し、ワークフロー設定を更新しました。権限設定を強化し、リリースドラフター処理の信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->