### PR TITLE
対象のブランチをmainからmasterへ変更

### DIFF
--- a/.github/workflows/git-pr-release.yml
+++ b/.github/workflows/git-pr-release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: bakunyo/git-pr-release-action@master
         env:
           GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_PR_RELEASE_BRANCH_PRODUCTION: main
+          GIT_PR_RELEASE_BRANCH_PRODUCTION: master
           GIT_PR_RELEASE_BRANCH_STAGING: develop
           GIT_PR_RELEASE_LABELS: release
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
git-pr-releaseがずっと失敗していたのを修正


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub ワークフロー設定の更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->