### PR TITLE
pnpm v11対応: onlyBuiltDependencies を allowBuilds に移行

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
   - '.'
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
+allowBuilds:
+  '@parcel/watcher': true


### PR DESCRIPTION
## 概要

pnpm v11 で削除された `onlyBuiltDependencies` 設定を、新形式の `allowBuilds` マップに移行します。

## 背景 / 問題

Renovate PR #1470（pnpm v10 → v11.1.2 のメジャーアップグレード）の CI (`rspec_job`) が `pnpm install` ステップで失敗していました。

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6
##[error]Process completed with exit code 1.
```

原因は pnpm v11 の破壊的変更:

- `onlyBuiltDependencies` / `neverBuiltDependencies` 等の設定キーが**削除**され、新しい `allowBuilds`（マップ形式）に統合された
- `strictDepBuilds` のデフォルトが `true` になり、未承認のビルドスクリプトがあると `pnpm install` が**異常終了**するようになった

`pnpm-workspace.yaml` が旧キーのままだったため、pnpm v11 が `@parcel/watcher` を未承認ビルドと判定し失敗していました。

## 変更内容

```diff
-onlyBuiltDependencies:
-  - '@parcel/watcher'
+allowBuilds:
+  '@parcel/watcher': true
```

## 影響範囲 / 互換性

- **pnpm v11**（#1470 リベース後）: `allowBuilds` を認識し `@parcel/watcher` をビルド → CI 緑
- **master / pnpm v10.33.2**: `allowBuilds` は未知キーとして無視され、ビルド未承認は警告のみ（exit 0）→ CI 緑を維持。`@parcel/watcher` はオプショナルな native 依存で、CI（テスト/ビルド、watch 非使用）には不要

このPRを先行マージ後、#1470 をリベースすれば pnpm v11 アップグレードが通ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)