### PR TITLE
pnpm v11対応: develop の onlyBuiltDependencies を allowBuilds に移行

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
   - '.'
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
+allowBuilds:
+  '@parcel/watcher': true


### PR DESCRIPTION
## 概要

`develop` をベースとする全PR（#1469〜#1475）の CI `Install dependencies` が以下で失敗している問題を解消します。

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6
##[error]Process completed with exit code 1.
```

## 原因

- `develop` の `package.json` は `packageManager: pnpm@11.1.0` のため CI は pnpm v11 で動作
- しかし `pnpm-workspace.yaml` は pnpm v10 のキー `onlyBuiltDependencies` のまま
- pnpm v11 では当該キーが廃止され `@parcel/watcher` のネイティブビルドが許可されず install が exit 1

master には #1476 で同等修正が既に取り込み済みですが、master→develop 同期は月次のため develop に未反映でした。`fix/pnpm-v11-allow-builds` をそのまま develop に向けるとベースが古く無関係な変更（Gemfile.lock 等）を巻き戻すため、develop から `pnpm-workspace.yaml` の1ファイルのみを修正しています。

## 変更内容

- pnpm v11 で廃止された `onlyBuiltDependencies` を削除し、新形式 `allowBuilds` マップへ移行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * ワークスペースのパッケージビルド構成を更新しました。これにより、ビルドプロセスの効率性が向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaki-org/baukis2/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->