### PR TITLE
Build CI を高速化(依存解決キャッシュの追加)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready --health-interval 3s --health-timeout 5s --health-retries 5 --health-start-period 5s
 
     # https://github.com/ruby/setup-ruby
     steps:
@@ -39,12 +39,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Ruby version
-        uses: ruby/setup-ruby@master
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: .tool-versions
-
-      - name: Setup bundler
-        run: gem install bundler
+          bundler-cache: true
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
@@ -52,15 +50,32 @@ jobs:
           package-manager-cache: false
       - name: Install pnpm
         uses: pnpm/action-setup@v6
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm install
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
-
-      - name: bundle install
-        run: |
-          bundle config set path 'vendor/bundle'
-          bundle install --jobs 4 --retry 3
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
       - name: Setup Database
         run: |
           cp config/database.yml.github-actions config/database.yml


### PR DESCRIPTION
## 概要

`develop` の Build CI(`.github/workflows/ruby.yml`)の `rspec_job` を高速化します。実測 run [25578670905](https://github.com/kaki-org/baukis2/actions/runs/25578670905) を分析した結果、**ボトルネックはテストではなく依存解決のキャッシュ欠如**でした。

## 変更内容

- **A**: `ruby/setup-ruby@master` → `@v1` + `bundler-cache: true` 化。手動の `gem install bundler` / `bundle install` ステップを廃止(`rubocop.yml` で実績ある手法)
- **B**: Playwright ブラウザを `actions/cache` でキャッシュ。ヒット時は `install-deps` のみ実行
- **C**: pnpm store を `actions/cache` でキャッシュ
- **D**: postgres service の `--health-interval` を `10s` → `3s`(+ `--health-start-period 5s`)

## 設定前後の比較

### 計測元
実測: Build run [25578670905](https://github.com/kaki-org/baukis2/actions/runs/25578670905)(rspec_job 3分01秒 / ワークフロー全体 3分18秒、success)

### ステップ別 所要時間(Before = 実測値 / After = キャッシュヒット時の見込み)

| ステップ | Before(実測) | After(見込み) | 改善内容 |
|---|---|---|---|
| `bundle install` | **58秒** | 約 5〜15秒 | A: bundler-cache 導入 |
| `Playwright install` | **30秒** | 約 2〜5秒 | B: ブラウザキャッシュ + deps のみ |
| `pnpm install` | 2〜3秒 | ほぼ 0 | C: pnpm store キャッシュ |
| `Initialize postgres` | 19秒 | 約 5〜8秒 | D: health-interval 短縮 |
| `Run RSpec` | 40秒 | 40秒(変更なし) | - |
| `Precompile assets` | 15秒 | 15秒(変更なし) | - |
| **ワークフロー全体** | **約 3分18秒** | **約 2分前後** | **-60〜95秒** |

### 設定差分の要点

| 項目 | Before | After |
|---|---|---|
| setup-ruby | `@master`(キャッシュ無し) | `@v1` + `bundler-cache: true` |
| bundler | `gem install bundler` 手動 | setup-ruby が自動管理 |
| bundle install | 手動ステップ(58秒フル) | キャッシュ復元(`Gemfile.lock` キー) |
| Playwright | 毎回フル DL(`--with-deps`) | キャッシュ + ヒット時 `install-deps` のみ |
| pnpm store | キャッシュ無し | `actions/cache`(`pnpm-lock.yaml` キー) |
| postgres health | `--health-interval 10s` | `--health-interval 3s` + `start-period 5s` |

※ After はキャッシュヒット時(2回目以降)の見込み値。初回および lock ファイル変更時はキャッシュミスのため Before 相当。RSpec/assets は本 PR の対象外(テスト規模が小さく並列化は時期尚早のため)。

## 実測結果(検証済み)

本ブランチで Build を 2 回実行し、見込みどおりの短縮を確認しました。

- 1回目 = 初回(キャッシュミス、キャッシュ生成): run [25957584426 attempt 1](https://github.com/kaki-org/baukis2/actions/runs/25957584426/attempts/1)
- 2回目 = 再実行(**キャッシュヒット**): run [25957584426 attempt 2](https://github.com/kaki-org/baukis2/actions/runs/25957584426/attempts/2)

### 全体所要時間

| | 元 Before<br>(25578670905) | 初回=キャッシュミス<br>(attempt 1) | **2回目=キャッシュヒット**<br>(attempt 2) |
|---|---|---|---|
| ワークフロー全体 | 約 3分18秒 | 約 3分07秒 | **2分12秒** |
| rspec_job | 3分01秒(181秒) | 2分54秒(174秒) | **1分54秒(114秒)** |

**キャッシュヒット時: 元 Before 比 約 -66秒(全体 約33%短縮)/ rspec_job -67秒(約37%短縮)。** 見込み「-60〜95秒・約2分前後」に合致。

### ステップ別 実測(秒)

| ステップ | 元 Before | キャッシュミス(初回) | **キャッシュヒット(2回目)** |
|---|---|---|---|
| Initialize postgres | 19 | 11 | **12** |
| Setup Ruby + bundle install | 58(bundle install) | 61 | **5** |
| Install pnpm | 3 | 3 | 2 |
| Cache pnpm store + pnpm install | 2〜3 | 2 | **3**(復元含む) |
| Playwright(install / deps) | 30 | 21(フル install) | **0 / 13**(deps のみ) |
| Setup Database | 4 | 6 | 5 |
| Precompile assets | 15 | 14 | 14 |
| Run RSpec | 40 | 42 | 42 |

最大効果は **A(bundler-cache)**: `Setup Ruby + bundle install` が 58〜61秒 → **5秒**(約 -55秒)。次いで B(Playwright)約 -17秒、D(postgres)約 -7秒。RSpec/Precompile は想定どおり変化なし。

> 注: 初回(キャッシュミス)でも D の効果で元 Before より約 11秒速い。短縮効果の本体は **2回目以降**に発現します(キャッシュは初回 run 終了時に生成済み)。

## リスク

いずれも低リスク。`bundler-cache: true` は同リポジトリ `rubocop.yml` で実績あり。Playwright のキャッシュ・条件分岐は公式推奨パターン。マージ後の最初の run でキャッシュが生成され、2回目以降から短縮効果を確認できます(本ブランチで検証済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
