### PR TITLE
auto-merge の squash を merge に変更

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Enable auto-merge
         run: |
-          gh pr merge --auto --squash --repo "$GH_REPO" "$PR_NUMBER"
+          gh pr merge --auto --merge --repo "$GH_REPO" "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## 概要

Dependabot Auto Merge ワークフローが `--squash` オプションでマージしようとしていたが、リポジトリでスカッシュマージが無効なため失敗していた。

## 原因

```
GraphQL: Squash merges are not allowed on this repository. (mergePullRequest)
```

リポジトリの設定:
- `allow_merge_commit: true`
- `allow_squash_merge: false`
- `allow_rebase_merge: false`

## 変更内容

`gh pr merge --auto --squash` → `gh pr merge --auto --merge` に変更。

## 関連

- https://github.com/kaki-org/baukis2/actions/runs/27586193629/job/81556944237?pr=1519


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の自動マージワークフローを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->