### PR TITLE
CLAUDE.md をディレクトリ分割し packs 共通規約を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,73 +1,21 @@
 # CLAUDE.md
 
-このファイルは、このリポジトリのコードを扱う際のClaude Code (claude.ai/code) への指針を提供します。
+Baukis2 は packwerk でモジュラー化された Rails 顧客管理システム。
+- スタッフ: http://baukis2.lvh.me:23000/
+- 管理者: http://baukis2.lvh.me:23000/admin
+- 顧客: http://lvh.me:23000/mypage
 
-## プロジェクト概要
+## コマンドは全て dip 経由で実行する
+Ruby と gem は Docker コンテナ内にのみ存在するため、ホストで直接 bundle exec を実行すると失敗する。
+- テスト: dip rspec [path] (RAILS_ENV=test は自動設定される)
+- lint: dip rubocop / 自動修正 dip rubocop -a
+- サーバ: dip rails s (http://baukis2.lvh.me:23000)
+- 依存: dip bundle install / dip pnpm install / dip pnpm build
+- DB: dip rails db:migrate / dip rails db:seed
+- 初期セットアップ: dip provision
 
-Baukis2は、packwerkベースのモジュラーアーキテクチャを採用したRuby on Rails顧客管理システムです。3つの異なるインターフェースがあります：
-- スタッフインターフェース: `http://baukis2.lvh.me:23000/`
-- 管理者インターフェース: `http://baukis2.lvh.me:23000/admin`
-- 顧客インターフェース: `http://lvh.me:23000/mypage`
-
-## アーキテクチャ
-
-### Packwerk構造
-コードベースはPackwerkを使用してモジュラーの境界を強制します：
-- `/packs/staff/` - スタッフ機能
-- `/packs/admin/` - 管理機能
-- `/packs/customer/` - 顧客向け機能
-
-各パックは独自のMVC構造、ルート、テストを含み、`package.yml`で定義された依存関係が強制されます。
-
-### 主要パターン
-- **Form Objects**: 複雑なバリデーション（例：`Staff::LoginForm`）
-- **Presenters**: ビューロジックの分離（例：`StaffMemberPresenter`）
-- **Service Objects**: ビジネスロジックのカプセル化（例：`Staff::Authenticator`）
-- **Concerns**: 共有機能（`EmailHolder`、`PasswordHolder`など）
-
-## 開発コマンド
-
-### セットアップとサーバー
-```bash
-dip provision          # 初期セットアップ
-dip rails db:migrate   # マイグレーション実行
-dip rails db:seed      # データベースシード
-dip rails s            # サーバー開始
-```
-
-### テスト
-```bash
-dip rspec                           # 全テスト実行
-dip rspec spec/path/to/test_spec.rb # 特定のテスト実行
-```
-
-### コード品質
-```bash
-dip rubocop        # リンティング実行
-dip rubocop -a     # 問題の自動修正
-dip brakeman       # セキュリティ分析
-```
-
-### パッケージ管理
-```bash
-dip bundle install  # Ruby依存関係
-dip pnpm install    # JavaScript依存関係
-dip pnpm build      # JavaScriptビルド
-```
+## packwerk 境界
+全パックが enforce_dependencies / enforce_privacy: true。既存違反は packs/*/package_todo.yml に猶予登録されているだけで、新規のパック外定数参照は CI (danger-packwerk) で検出される。新規コードで package_todo.yml に頼らない。パック間参照の正しい方法は packs/CLAUDE.md を参照。
 
 ## 技術スタック
-- Ruby 4.0.0, Rails 8.0.0
-- PostgreSQL 17
-- Stimulus, Turbo Rails, Webpack
-- テスト用RSpec with Capybara/Playwright
-- オーケストレーション用Docker with dip
-
-## ファイル構成
-- パックルート: `/packs/*/config/routes/*.rb`
-- 共有ビュー: `/app/views/shared/`
-- レイアウト: `/app/views/layouts/`（各インターフェース別）
-- シード: `/packs/*/db/seeds/development/`
-- ロケール: `/config/locales/`（日本語がデフォルト）
-
-## テスト構造
-テストは各パックの`spec/`ディレクトリ内に配置されます。RSpec、FactoryBot、Playwrightドライバーによるシステムテストを使用します。
+Ruby 4.0.0 / Rails 8.1 / PostgreSQL 18 / RSpec + Capybara (Playwright) / webpack + pnpm (Shakapacker 不使用) / Stimulus。i18n デフォルトは ja、タイムゾーンは Tokyo。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Ruby と gem は Docker コンテナ内にのみ存在するため、ホスト�
 - 初期セットアップ: dip provision
 
 ## packwerk 境界
-全パックが enforce_dependencies / enforce_privacy: true。既存違反は packs/*/package_todo.yml に猶予登録されているだけで、新規のパック外定数参照は CI (danger-packwerk) で検出される。新規コードで package_todo.yml に頼らない。パック間参照の正しい方法は packs/CLAUDE.md を参照。
+全パックが enforce_dependencies / enforce_privacy: true。既存違反はルートと各パックの package_todo.yml に猶予登録されているだけで、新規のパック外定数参照は CI (danger-packwerk) で検出される。新規コードで package_todo.yml に頼らない。パック間参照の正しい方法は packs/CLAUDE.md を参照。
 
 ## 技術スタック
 Ruby 4.0.0 / Rails 8.1 / PostgreSQL 18 / RSpec + Capybara (Playwright) / webpack + pnpm (Shakapacker 不使用) / Stimulus。i18n デフォルトは ja、タイムゾーンは Tokyo。

--- a/packs/CLAUDE.md
+++ b/packs/CLAUDE.md
@@ -18,4 +18,4 @@ staff は customer と root (.) に依存できる。admin と customer は依�
 Address (customer パック) は本物の STI 親 (HomeAddress / WorkAddress が継承)。StaffEvent (staff パック) は self.inheritance_column = nil で STI を無効化し、type は 'logged_in' 等の生の文字列カラム。type カラムを見て一律に STI と判断しない。
 
 ## テストと seeds
-新規テストと factory は対象パック内の spec/ に置き、既存の類似 spec を手本にする。システムテストのドライバはデフォルト :rack_test で、:js タグを付けた example だけが :playwright で動く (spec/rails_helper.rb)。seeds は packs/<パック>/db/seeds/<環境名>/*.rb に置く (db/seeds.rb が環境ごとに glob ロード)。
+新規テストと factory は対象パック内の spec/ に置き、既存の類似 spec を手本にする。システムテストのドライバはデフォルト :rack_test で、:js と :system の両メタデータを持つ example だけが :playwright で動く (spec/rails_helper.rb。type: :system は spec/system 配下で自動付与されるため、実際には :js タグを足せばよい)。seeds は packs/<パック>/db/seeds/<環境名>/*.rb に置く (db/seeds.rb が環境ごとに glob ロード)。

--- a/packs/CLAUDE.md
+++ b/packs/CLAUDE.md
@@ -1,0 +1,21 @@
+# packs 共通規約
+
+packs/staff・packs/admin・packs/customer は packwerk パック。各パックが app / config/routes / spec / db/seeds を内包する。パック横断で共有されるコード (model concerns、Presenter 基底クラス、AdminService) だけがルートの app/ に置かれる。
+
+## 名前空間は層で使い分ける
+コントローラ・Form Object・Authenticator は Staff:: / Admin:: 名前空間 (packs/staff/app/forms/staff/login_form.rb → Staff::LoginForm)。モデルと Presenter はトップレベル (packs/staff/app/models/staff_member.rb → StaffMember。staff サブディレクトリなし)。パック内だからといってモデルに Staff:: を付けると別定数になり、既存コードと繋がらない。
+
+## 他パックのモデルは Service レジストリ経由で参照する
+StaffService.customer / AdminService.staff_member のように、initializer で登録されたレジストリからクラスを取得する。他パックのモデルを裸の定数で書くと packwerk の新規違反になる (関連名のシンボルや class_name の文字列は検出対象外)。レジストリ本体: packs/staff/app/services/staff_service.rb と app/services/admin_service.rb。登録処理: packs/*/config/initializers/configure_*.rb。
+
+## 依存関係 (package.yml)
+staff は customer と root (.) に依存できる。admin と customer は依存宣言なし: admin は AdminService 経由でのみ staff のデータに触れる。customer は依存される側のリーフで、他パックへの依存を追加しない。
+
+## ルーティング
+新ルートは対象パックの packs/*/config/routes/*.rb に手で書く。generator は skip_routes 設定 (config/application.rb) のためルートを自動追記しない。ホスト分離 (staff/admin: baukis2.lvh.me、customer: lvh.me) は各 routes ファイルの constraints host: が担い、設定値は config/initializers/baukis2.rb にある。
+
+## type カラムの意味は2通りある
+Address (customer パック) は本物の STI 親 (HomeAddress / WorkAddress が継承)。StaffEvent (staff パック) は self.inheritance_column = nil で STI を無効化し、type は 'logged_in' 等の生の文字列カラム。type カラムを見て一律に STI と判断しない。
+
+## テストと seeds
+新規テストと factory は対象パック内の spec/ に置き、既存の類似 spec を手本にする。システムテストのドライバはデフォルト :rack_test で、:js タグを付けた example だけが :playwright で動く (spec/rails_helper.rb)。seeds は packs/<パック>/db/seeds/<環境名>/*.rb に置く (db/seeds.rb が環境ごとに glob ロード)。


### PR DESCRIPTION
## 概要

AI コーディングエージェント向けの CLAUDE.md をディレクトリ分割し、「そのコードを触るときに必ず読まれる階層」に規約を再配置します。

- ルート CLAUDE.md: 全セッションで効く事項のみに絞り込み (dip 経由コマンド / packwerk 境界 / 技術スタック)。Rails 8.0.0→8.1、PostgreSQL 17→18 の誤記も修正
- packs/CLAUDE.md (新規): packs 配下を触るときに読まれる共通規約を集約

## packs/CLAUDE.md に集約した規約

- 名前空間は層で使い分ける (コントローラ/Form は Staff::、モデル/Presenter はトップレベル)
- 他パックのモデルは Service レジストリ (StaffService / AdminService) 経由で参照する
- package.yml の依存関係 (admin/customer は依存宣言なし)
- 新ルートはパックの routes ファイルに手書き (generator は skip_routes)
- type カラムの2義性 (Address は STI / StaffEvent は非 STI)
- テスト・factory・seeds はパック内に配置、:js タグのみ Playwright

## 選定プロセス

Opus サブエージェント 6 体で「CLAUDE.md あり/なし」の A/B 検証を実施し、探索だけで正解に到達できる項目 (日本語ラベル指定、ログインヘルパー名など) を削除。挙動差 (不確実性の解消・packwerk 規約違反提案の防止) が確認できた項目のみ残しています。当初 7 ファイル案から 2 ファイルに削減しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 開発・運用手順を再整理し、対象インターフェースURLやコマンド実行フロー、テスト／DB操作のルールを明確化しました。
  * Packwerk運用ガイドを新規追加し、パック間の参照範囲、名前空間の方針、ルーティング／テスト設定、シードの配置と読み込み方式を具体化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->